### PR TITLE
Arregla validación del destinatario

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ node index.js
 
 ## Google Sheets (opcional)
 Si proporcionás las variables `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY` y `GOOGLE_SHEET_ID`, cada mensaje o CV recibido se registrará en la hoja especificada.
+
+## Recomendaciones para n8n
+
+El endpoint `/send-message` validará que el campo `to` termine en `@c.us`. Si el número es inválido o está vacío, la API devolverá **400 Bad Request** antes de contactar a WhatsApp.
+
+Para evitar errores, asegurate de armar el JSON del HTTP Request en n8n así:
+
+```json
+{
+  "to": "{{ $json.to || $json.sessionId }}",
+  "text": "{{ $json.text }}"
+}
+```

--- a/index.js
+++ b/index.js
@@ -244,11 +244,11 @@ app.post('/send-message', async (req, res) => {
   const { to, text } = req.body;
   console.log('🔔 Solicitud de envío de mensaje:', { to, text });
 
-  if (!to || typeof to !== 'string') {
+  if (!to || typeof to !== 'string' || to.trim() === '' || to === 'undefined' || !to.endsWith('@c.us')) {
     console.error('❌ Número inválido (to):', to);
-    return res.status(400).json({ error: 'Número inválido.' });
+    return res.status(400).json({ error: 'Número inválido. Debe terminar en @c.us' });
   }
-  const numeroDestino = to.endsWith('@c.us') ? to : `${to}@c.us`;
+  const numeroDestino = to;
 
   if (!text || typeof text !== 'string' || text.trim() === '') {
     console.error('❌ Texto inválido:', text);


### PR DESCRIPTION
## Summary
- valida el campo `to` en `/send-message`
- documenta en el README cómo armar el JSON desde n8n

## Testing
- `npm test` *(falla: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_684b24e919948320b408482af0277ca5