### PR TITLE
Add CV-only n8n workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,17 @@ El archivo `index.js` envía al webhook un JSON con las siguientes propiedades c
 ```
 
 Si el mensaje incluye un CV en lugar de `message` se envían `filename`, `mimetype` y `data_base64` con el archivo en base64. En ambos casos se adjunta `context` con los últimos mensajes de la conversación.
+
+## Workflow especializado para CVs
+
+El archivo `wspautoresponse_cv.json` implementa un flujo dedicado exclusivamente a procesar CVs recibidos por WhatsApp. Su funcionamiento es el siguiente:
+
+1. Recibe el mensaje mediante el webhook `whatsapp-in`.
+2. Verifica que el adjunto sea un PDF válido. Si no lo es, responde con un mensaje de error.
+3. Guarda el archivo en `./files/cv/` con el nombre `<timestamp>_<remitente>.pdf`.
+4. Extrae el texto del PDF utilizando `pdf-parse`.
+5. Envía dicho texto a OpenAI para generar un resumen con nombre, experiencia, formación, habilidades, idiomas, clasificación y keywords.
+6. Devuelve la respuesta al remitente vía `/send-message`.
+7. Guarda el resumen generado en un archivo JSON para su posterior revisión.
+
+Este flujo elimina la antigua clasificación de mensajes (PEDIDO/CONSULTA/OTRO) y se centra únicamente en el análisis automático de CVs.

--- a/wspautoresponse_cv.json
+++ b/wspautoresponse_cv.json
@@ -1,0 +1,143 @@
+{
+  "name": "AI WhatsApp CV Auto Response",
+  "nodes": [
+    {
+      "parameters": {
+        "path": "whatsapp-in",
+        "options": {}
+      },
+      "id": "webhook-node",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [300, 300]
+    },
+    {
+      "parameters": {
+        "functionCode": "const msg = $json;\nconst item = {\n  desde: msg.desde,\n  sender: msg.sender,\n  timestamp: msg.timestamp,\n};\nif (msg.filename && msg.mimetype) {\n  item.filename = msg.filename;\n  item.mimetype = msg.mimetype;\n  item.data_base64 = msg.data_base64;\n  item.isPDF = msg.mimetype === 'application/pdf';\n} else {\n  item.isPDF = false;\n}\nreturn [item];"
+      },
+      "id": "parse-node",
+      "name": "Parse Message",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [500, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json.isPDF }}",
+              "operation": "equal",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "id": "check-pdf",
+      "name": "¿Es PDF?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [700, 300]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:3000/send-message",
+        "method": "POST",
+        "jsonParameters": true,
+        "options": {},
+        "bodyParametersJson": "={\n  \"to\": \"{{ $json.desde }}\",\n  \"text\": \"El archivo recibido no es un CV en PDF.\"\n}"
+      },
+      "id": "error-response",
+      "name": "Responder Error",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [900, 150]
+    },
+    {
+      "parameters": {
+        "functionCode": "const fs = require('fs');\nconst path = `/files/cv/${Date.now()}_${$json.sender.replace(/[^a-zA-Z0-9]/g,'_')}.pdf`;\nfs.mkdirSync('/files/cv', { recursive: true });\nfs.writeFileSync(path, Buffer.from($json.data_base64, 'base64'));\nitem.file_path = path;\nreturn [item];"
+      },
+      "id": "save-pdf",
+      "name": "Guardar PDF",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "functionCode": "const fs = require('fs');\nconst pdfParse = require('pdf-parse');\nconst data = fs.readFileSync($json.file_path);\nconst res = await pdfParse(data);\nitem.cv_text = res.text;\nreturn [item];"
+      },
+      "id": "pdf-text",
+      "name": "Extraer texto",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [1100, 300]
+    },
+    {
+      "parameters": {
+        "modelId": {
+          "value": "gpt-4o",
+          "mode": "list",
+          "cachedResultName": "GPT-4O"
+        },
+        "messages": {
+          "values": [
+            {
+              "content": "=Con el siguiente CV en texto plano: {{ $json.cv_text }}\nGenera un resumen con nombre, experiencia laboral, formacion academica, habilidades tecnicas, idiomas, clasificacion (junior/senior/tecnico/pasante) y keywords."
+            }
+          ]
+        }
+      },
+      "id": "openai-summarize",
+      "name": "Analizar CV",
+      "type": "@n8n/n8n-nodes-langchain.openAi",
+      "typeVersion": 1.8,
+      "position": [1300, 300],
+      "credentials": {
+        "openAiApi": {
+          "id": "YOUR_CRED_ID",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:3000/send-message",
+        "method": "POST",
+        "jsonParameters": true,
+        "options": {},
+        "bodyParametersJson": "={\n  \"to\": \"{{ $json.desde }}\",\n  \"text\": \"{{ $json.message }}\"\n}"
+      },
+      "id": "send-response",
+      "name": "Responder Analisis",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [1500, 300]
+    },
+    {
+      "parameters": {
+        "functionCode": "const fs = require('fs');\nconst path = `/files/cv/${Date.now()}_${$json.sender.replace(/[^a-zA-Z0-9]/g,'_')}.json`;\nfs.mkdirSync('/files/cv', { recursive: true });\nfs.writeFileSync(path, JSON.stringify($json.message, null, 2));\nreturn [item];"
+      },
+      "id": "save-summary",
+      "name": "Guardar Resumen",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [1700, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {"main": [[{"node": "Parse Message", "type": "main", "index": 0}]]},
+    "Parse Message": {"main": [[{"node": "¿Es PDF?", "type": "main", "index": 0}]]},
+    "¿Es PDF?": {
+      "main": [
+        [{"node": "Guardar PDF", "type": "main", "index": 0}],
+        [{"node": "Responder Error", "type": "main", "index": 0}]
+      ]
+    },
+    "Guardar PDF": {"main": [[{"node": "Extraer texto", "type": "main", "index": 0}]]},
+    "Extraer texto": {"main": [[{"node": "Analizar CV", "type": "main", "index": 0}]]},
+    "Analizar CV": {"main": [[{"node": "Responder Analisis", "type": "main", "index": 0}]]},
+    "Responder Analisis": {"main": [[{"node": "Guardar Resumen", "type": "main", "index": 0}]]}
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `wspautoresponse_cv.json` n8n workflow focused only on CV processing
- document the specialized workflow in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c0bb11134832084c2e45d97da5770