### PR TITLE
Add PDF parser API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ node index.js
 3. Escaneá el código QR que aparecerá en consola para vincular WhatsApp Web.
 4. Asegurate de que n8n tenga un webhook público accesible en `N8N_WEBHOOK_URL`.
 5. Si configurás `INIT_PHONE` en `.env`, el bot enviará un mensaje de bienvenida a ese número cuando la sesión se inicie.
+6. Para iniciar el bot, la API de PDFs y n8n simultáneamente ejecutá:
+```bash
+npm run stack
+```
+Esto asume que tenés `n8n` instalado de forma global o como dependencia del proyecto.
 
 ## Google Sheets (opcional)
 Si proporcionás las variables `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_PRIVATE_KEY` y `GOOGLE_SHEET_ID`, cada mensaje o CV recibido se registrará en la hoja especificada.
@@ -90,3 +95,39 @@ El archivo `wspautoresponse_cv.json` implementa un flujo dedicado exclusivamente
 7. Guarda el resumen generado en un archivo JSON para su posterior revisión.
 
 Este flujo elimina la antigua clasificación de mensajes (PEDIDO/CONSULTA/OTRO) y se centra únicamente en el análisis automático de CVs.
+
+## API local para extraer texto de PDFs
+
+Para facilitar el análisis de CVs en n8n se incluyó una pequeña API independiente en `pdf-parser-api/`. Su propósito es recibir un PDF en base64 y devolver el texto extraído.
+
+### Uso
+
+```bash
+cd pdf-parser-api
+npm install
+node pdf-api.js
+```
+
+Esto levantará el servicio en `http://localhost:3001` y mostrará:
+
+```
+📄 PDF extractor API on http://localhost:3001
+```
+
+### Endpoint
+
+`POST /parse-pdf`
+
+Cuerpo JSON:
+
+```json
+{ "base64": "<contenido_base64_del_pdf>" }
+```
+
+Respuesta:
+
+```json
+{ "text": "Texto plano extraído del PDF" }
+```
+
+Este servicio puede consumirse desde el flujo de n8n mediante una solicitud HTTP para obtener el texto antes de enviarlo a OpenAI.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start:bot": "node index.js",
+    "start:pdf": "node pdf-parser-api/pdf-api.js",
+    "start:n8n": "n8n start",
+    "stack": "concurrently -k \"npm run start:bot\" \"npm run start:pdf\" \"npm run start:n8n\"",
+    "postinstall": "npm install --prefix pdf-parser-api"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +21,7 @@
     "express": "^5.1.0",
     "google-spreadsheet": "^4.1.4",
     "qrcode-terminal": "^0.12.0",
-    "whatsapp-web.js": "^1.30.0"
+    "whatsapp-web.js": "^1.30.0",
+    "concurrently": "^8.2.0"
   }
 }

--- a/pdf-parser-api/package.json
+++ b/pdf-parser-api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pdf-parser-api",
+  "version": "1.0.0",
+  "main": "pdf-api.js",
+  "scripts": {
+    "start": "node pdf-api.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pdf-parse": "^1.1.1"
+  }
+}

--- a/pdf-parser-api/pdf-api.js
+++ b/pdf-parser-api/pdf-api.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const pdf = require('pdf-parse');
+
+const app = express();
+app.use(express.json({ limit: '50mb' }));
+
+app.post('/parse-pdf', async (req, res) => {
+  const { base64 } = req.body || {};
+  if (!base64 || typeof base64 !== 'string') {
+    return res.status(400).json({ error: 'Missing base64' });
+  }
+
+  try {
+    const buffer = Buffer.from(base64, 'base64');
+    const data = await pdf(buffer);
+    res.json({ text: data.text });
+  } catch (err) {
+    console.error('Error parsing PDF:', err.message);
+    res.status(500).json({ error: 'Failed to parse PDF' });
+  }
+});
+
+const PORT = 3001;
+app.listen(PORT, () => {
+  console.log(`\uD83D\uDCC4 PDF extractor API on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement `pdf-parser-api/pdf-api.js` to extract text from base64 PDFs
- add minimal `package.json` for the API
- document new service in README
- allow running bot, PDF API and n8n in parallel using npm `stack` script

## Testing
- `npm test` *(fails: Error: no test specified)*
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm run stack` *(fails: n8n not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b9beae08320aecaa5b1ed051dd8