### PR TITLE
Improve base64 validation in pdf API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ Para evitar errores, asegurate de armar el JSON del HTTP Request en n8n así:
 }
 ```
 
+Cuando se envíe un PDF al endpoint `parse-pdf`, usa una función previa para
+convertir el binario a base64:
+
+```javascript
+item.json.base64 = Buffer.from(item.binary.data.data).toString('base64');
+return item;
+```
+
+Esto garantiza que la cadena sea válida antes de hacer el POST.
+
 ## Estructura del payload enviado a n8n
 
 El archivo `index.js` envía al webhook un JSON con las siguientes propiedades cuando recibe un mensaje de texto:
@@ -143,3 +153,16 @@ Respuesta:
 ```
 
 Este servicio puede consumirse desde el flujo de n8n mediante una solicitud HTTP para obtener el texto antes de enviarlo a OpenAI.
+
+#### Prueba rápida con cURL
+
+1. Guarda un PDF de prueba en la carpeta `pdf-parser-api` con el nombre `sample.pdf`.
+2. Ejecuta el siguiente comando para codificarlo en base64 y enviarlo al API:
+
+```bash
+base64 sample.pdf | curl -X POST http://localhost:3001/parse-pdf \
+  -H "Content-Type: application/json" \
+  -d @- | jq
+```
+
+Deberías obtener un JSON con el texto extraído. Esto permite validar que el endpoint funciona correctamente sin necesidad de n8n.

--- a/pdf-parser-api/pdf-api.js
+++ b/pdf-parser-api/pdf-api.js
@@ -7,17 +7,32 @@ app.use(express.json({ limit: '50mb' }));
 app.post('/parse-pdf', async (req, res) => {
   const { base64 } = req.body || {};
   if (!base64 || typeof base64 !== 'string') {
-    return res.status(400).json({ error: 'Missing base64' });
+    return res.status(400).json({ error: 'Missing base64 field' });
+  }
+
+  // Remove possible data URI prefix
+  const cleanBase64 = base64.replace(/^data:.*;base64,/, '').trim();
+
+  // Basic base64 validation
+  if (!/^[A-Za-z0-9+/=]+$/.test(cleanBase64)) {
+    return res.status(400).json({ error: 'Invalid base64 data' });
   }
 
   try {
-    const buffer = Buffer.from(base64, 'base64');
+    const buffer = Buffer.from(cleanBase64, 'base64');
+    if (!buffer.length) {
+      return res.status(400).json({ error: 'Empty PDF buffer' });
+    }
     const data = await pdf(buffer);
     res.json({ text: data.text });
   } catch (err) {
     console.error('Error parsing PDF:', err.message);
     res.status(500).json({ error: 'Failed to parse PDF' });
   }
+});
+
+app.get('/status', (_, res) => {
+  res.json({ ok: true });
 });
 
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- add base64 validation and `/status` route to `pdf-parser-api`
- document how to convert binary to base64 in n8n
- add quick cURL test example

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `node pdf-parser-api/pdf-api.js` *(manual)*
- `curl -X POST http://localhost:3001/parse-pdf --data-binary @request.json` *(manual)*

------
https://chatgpt.com/codex/tasks/task_e_684c3f154a6883208c87162ec6cf19dd