### PR TITLE
Improve PDF validation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,5 @@ base64 sample.pdf | curl -X POST http://localhost:3001/parse-pdf \
 ```
 
 Deberías obtener un JSON con el texto extraído. Esto permite validar que el endpoint funciona correctamente sin necesidad de n8n.
+
+> **Nota:** El servicio verifica que los primeros bytes del archivo correspondan a un PDF válido. Si envías una cadena base64 que no sea un PDF real o esté corrupto, obtendrás una respuesta **400** con un mensaje de error descriptivo.


### PR DESCRIPTION
## Summary
- validate the PDF buffer before parsing
- clarify README with note on invalid PDF handling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c474d4c608320ae9eb30f87e284fa